### PR TITLE
Create skaff.yaml

### DIFF
--- a/.skaff/skaff.yaml
+++ b/.skaff/skaff.yaml
@@ -1,0 +1,28 @@
+spec_version: 1
+
+# Everyting in this file will be used to populate the catalog on skaff.artefact.com
+# It is also vectorized as is for the search, so make sure to provide relevant keywords
+
+name: Terraform module GCP Org Policies
+owner: cedric.magnan@artefact.com
+description: >
+  Opinionated terraform module to apply default GCP organization, folders or projects policies.
+documentation_url: https://github.com/artefactory/terraform-google-cloud-policies/blob/main/README.md
+
+type: deployable      # deployable, knowldege pack
+lifecycle: prototype  # prototype, production
+
+users:                # DS, DA, DE
+  - DE
+
+clouds:               # aws, gcp, azure, databricks
+  - gcp
+
+technologies:         # python, dbt, terraform, airbyte, ...
+  - terraform
+
+expertises:        # MMM, forecasting, ELT, release engineering, ...
+  - policies
+  - security
+  - infrastructure as code
+  - cloud foundations


### PR DESCRIPTION
Hey,

On va bouger de roadie pour le catalogue, donc je t'ajoute ce remplacement du catalog-info.yaml. Je laisse ce dernier le temps de la migration, il sera supprimé une fois roadie définitivement déprécié. Une migration du repo vers l'org GitHub artefactory-skaff sera effectuée à ce moment là.

Pour info, le nouveau catalogue est à skaff.artefact.com.

Thanks !